### PR TITLE
chore: update cursor one click install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add this to your MCP client config to run the server via stdio:
 
 (Optionally) Add to Cursor (macOS/Linux):
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/en-US/install-mcp?name=datum-mcp&config=eyJjb21tYW5kIjoiZGF0dW0tbWNwIn0)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/en-US/install-mcp?name=datum-mcp&config=eyJ0eXBlIjoic3RkaW8iLCJlbnYiOnt9LCJjb21tYW5kIjoiL3Vzci9sb2NhbC9iaW4vZGF0dW0tbWNwICJ9)
 
 
 Windows:


### PR DESCRIPTION
This pull request updates the installation link for the MCP Server in the `README.md` file to ensure the server runs via stdio by default. This change will help users configure the MCP client more reliably when following setup instructions.

Documentation update:

* Updated the MCP Server installation link in `README.md` to include configuration for running the server via stdio.