### PR TITLE
feat: tool calls for dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # datum-mcp
 
-An MCP server for Datum Cloud with OAuth 2.1 (PKCE) auth, macOS Keychain token storage, and tools for listing/operating on organizations, projects, domains, HTTP proxies, HTTP routes, gateways, traffic protection policies, and CRD schemas.
+An MCP server for Datum Cloud with OAuth 2.1 (PKCE) auth, macOS Keychain token storage, and tools for listing/operating on organizations, projects, domains, HTTP proxies, HTTP routes, gateways, traffic protection policies, DNS zones/records, and CRD schemas.
 
 ## Installation
 
@@ -138,6 +138,38 @@ All tools accept JSON inputs and return both structured content and a pretty-pri
   - Policies are intended to target either `Gateway` or `HTTPRoute` resources.
   - Group/kind: `networking.datumapis.com` / `TrafficProtectionPolicy`.
 
+- dnszones
+  - **Actions**: `list` | `get` | `create` | `update` | `delete`
+  - **Input**:
+    - List: `{ "action": "list", "project": "<optional>" }`
+    - Get: `{ "action": "get", "id": "<name>", "project": "<optional>" }`
+    - Create: `{ "action": "create", "body": { ... }, "project": "<optional>" }`
+    - Update: `{ "action": "update", "id": "<name>", "body": { ... }, "project": "<optional>" }`
+    - Delete: `{ "action": "delete", "id": "<name>", "project": "<optional>" }`
+  - **Project resolution**: `project` input, else active project (from `projects set`).
+  - **Namespace**: operates in namespace `default`.
+  - **Group/kind**: `dns.networking.miloapis.com` / `DNSZone`.
+
+- dnsrecordsets
+  - **Actions**: `list` | `get` | `create` | `update` | `delete`
+  - **Input**:
+    - List: `{ "action": "list", "project": "<optional>" }`
+    - Get: `{ "action": "get", "id": "<name>", "project": "<optional>" }`
+    - Create: `{ "action": "create", "body": { ... }, "project": "<optional>" }`
+    - Update: `{ "action": "update", "id": "<name>", "body": { ... }, "project": "<optional>" }`
+    - Delete: `{ "action": "delete", "id": "<name>", "project": "<optional>" }`
+  - **Project resolution**: `project` input, else active project (from `projects set`).
+  - **Namespace**: operates in namespace `default`.
+  - **Group/kind**: `dns.networking.miloapis.com` / `DNSRecordSet`.
+
+- dnszoneclasses
+  - **Actions**: `list` | `get`
+  - **Input**:
+    - List: `{ "action": "list", "project": "<optional>" }`
+    - Get: `{ "action": "get", "id": "<name>", "project": "<optional>" }`
+  - **Scope**: cluster-scoped (no namespace).
+  - **Group/kind**: `dns.networking.miloapis.com` / `DNSZoneClass`.
+
 - apis (CRDs list/describe via upstream OpenAPI/`kubectl explain` logic)
   - **Actions**: `list` | `get`
   - **Input**:
@@ -152,5 +184,5 @@ All tools accept JSON inputs and return both structured content and a pretty-pri
 2. `organizations` → set active org
 3. `projects` → list for an org
 4. `projects` → set active project
-5. Use `domains` / `httpproxies` / `httproutes` / `gateways` / `trafficprotectionpolicies` for CRUD, or `apis` to inspect CRD schemas
+5. Use `domains` / `httpproxies` / `httproutes` / `gateways` / `trafficprotectionpolicies` / `dnszones` / `dnsrecordsets` / `dnszoneclasses` for CRUD/list/get, or `apis` to inspect CRD schemas
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -588,6 +588,178 @@ func toolTrafficProtectionPolicies(ctx context.Context, _ *mcp.CallToolRequest, 
 	}
 }
 
+// DNSZones tool supports: list|get|create|update|delete
+// Group/Kind: dns.networking.miloapis.com/DNSZone (namespaced)
+func toolDNSZones(ctx context.Context, _ *mcp.CallToolRequest, in RoutedInput) (*mcp.CallToolResult, any, error) {
+	_, err := auth.EnsureAuth(ctx)
+	if err != nil {
+		return &mcp.CallToolResult{IsError: true}, nil, err
+	}
+	p, err := resolveProjectName(in.Project)
+	if err != nil {
+		return &mcp.CallToolResult{IsError: true}, nil, err
+	}
+	cli, err := api.NewProjectControlPlaneClient(ctx, p)
+	if err != nil {
+		return &mcp.CallToolResult{IsError: true}, nil, err
+	}
+	const group = "dns.networking.miloapis.com"
+	const kind = "DNSZone"
+	const namespace = "default"
+	switch strings.ToLower(string(in.Action)) {
+	case string(ActionList):
+		list, err := api.FetchList(ctx, cli, group, kind, namespace)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		b, _ := json.MarshalIndent(list, "", "  ")
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, list, nil
+	case string(ActionGet):
+		if in.ID == "" {
+			return &mcp.CallToolResult{IsError: true}, nil, fmt.Errorf("invalid params: id is required")
+		}
+		obj, err := api.FetchObject(ctx, cli, group, kind, namespace, in.ID)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		b, _ := json.MarshalIndent(obj, "", "  ")
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, obj, nil
+	case string(ActionCreate):
+		obj, err := api.CreateObject(ctx, cli, group, kind, namespace, in.Body)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		b, _ := json.MarshalIndent(obj, "", "  ")
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, obj, nil
+	case string(ActionUpdate):
+		if in.ID == "" {
+			return &mcp.CallToolResult{IsError: true}, nil, fmt.Errorf("invalid params: id is required")
+		}
+		obj, err := api.UpdateObjectSpec(ctx, cli, group, kind, namespace, in.ID, in.Body)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		b, _ := json.MarshalIndent(obj, "", "  ")
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, obj, nil
+	case string(ActionDelete):
+		if in.ID == "" {
+			return &mcp.CallToolResult{IsError: true}, nil, fmt.Errorf("invalid params: id is required")
+		}
+		if err := api.DeleteObject(ctx, cli, group, kind, namespace, in.ID); err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "deleted"}}}, map[string]string{"deleted": in.ID}, nil
+	default:
+		return &mcp.CallToolResult{IsError: true}, nil, fmt.Errorf("unsupported dnszones action: %s", in.Action)
+	}
+}
+
+// DNSRecordSets tool supports: list|get|create|update|delete
+// Group/Kind: dns.networking.miloapis.com/DNSRecordSet (namespaced)
+func toolDNSRecordSets(ctx context.Context, _ *mcp.CallToolRequest, in RoutedInput) (*mcp.CallToolResult, any, error) {
+	_, err := auth.EnsureAuth(ctx)
+	if err != nil {
+		return &mcp.CallToolResult{IsError: true}, nil, err
+	}
+	p, err := resolveProjectName(in.Project)
+	if err != nil {
+		return &mcp.CallToolResult{IsError: true}, nil, err
+	}
+	cli, err := api.NewProjectControlPlaneClient(ctx, p)
+	if err != nil {
+		return &mcp.CallToolResult{IsError: true}, nil, err
+	}
+	const group = "dns.networking.miloapis.com"
+	const kind = "DNSRecordSet"
+	const namespace = "default"
+	switch strings.ToLower(string(in.Action)) {
+	case string(ActionList):
+		list, err := api.FetchList(ctx, cli, group, kind, namespace)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		b, _ := json.MarshalIndent(list, "", "  ")
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, list, nil
+	case string(ActionGet):
+		if in.ID == "" {
+			return &mcp.CallToolResult{IsError: true}, nil, fmt.Errorf("invalid params: id is required")
+		}
+		obj, err := api.FetchObject(ctx, cli, group, kind, namespace, in.ID)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		b, _ := json.MarshalIndent(obj, "", "  ")
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, obj, nil
+	case string(ActionCreate):
+		obj, err := api.CreateObject(ctx, cli, group, kind, namespace, in.Body)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		b, _ := json.MarshalIndent(obj, "", "  ")
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, obj, nil
+	case string(ActionUpdate):
+		if in.ID == "" {
+			return &mcp.CallToolResult{IsError: true}, nil, fmt.Errorf("invalid params: id is required")
+		}
+		obj, err := api.UpdateObjectSpec(ctx, cli, group, kind, namespace, in.ID, in.Body)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		b, _ := json.MarshalIndent(obj, "", "  ")
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, obj, nil
+	case string(ActionDelete):
+		if in.ID == "" {
+			return &mcp.CallToolResult{IsError: true}, nil, fmt.Errorf("invalid params: id is required")
+		}
+		if err := api.DeleteObject(ctx, cli, group, kind, namespace, in.ID); err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "deleted"}}}, map[string]string{"deleted": in.ID}, nil
+	default:
+		return &mcp.CallToolResult{IsError: true}, nil, fmt.Errorf("unsupported dnsrecordsets action: %s", in.Action)
+	}
+}
+
+// DNSZoneClasses tool supports: list|get (cluster-scoped)
+// Group/Kind: dns.networking.miloapis.com/DNSZoneClass (cluster-scoped)
+func toolDNSZoneClasses(ctx context.Context, _ *mcp.CallToolRequest, in RoutedInput) (*mcp.CallToolResult, any, error) {
+	_, err := auth.EnsureAuth(ctx)
+	if err != nil {
+		return &mcp.CallToolResult{IsError: true}, nil, err
+	}
+	p, err := resolveProjectName(in.Project)
+	if err != nil {
+		return &mcp.CallToolResult{IsError: true}, nil, err
+	}
+	cli, err := api.NewProjectControlPlaneClient(ctx, p)
+	if err != nil {
+		return &mcp.CallToolResult{IsError: true}, nil, err
+	}
+	const group = "dns.networking.miloapis.com"
+	const kind = "DNSZoneClass"
+	switch strings.ToLower(string(in.Action)) {
+	case string(ActionList):
+		list, err := api.FetchList(ctx, cli, group, kind, "")
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		b, _ := json.MarshalIndent(list, "", "  ")
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, list, nil
+	case string(ActionGet):
+		if in.ID == "" {
+			return &mcp.CallToolResult{IsError: true}, nil, fmt.Errorf("invalid params: id is required")
+		}
+		obj, err := api.FetchObject(ctx, cli, group, kind, "", in.ID)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, nil, err
+		}
+		b, _ := json.MarshalIndent(obj, "", "  ")
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, obj, nil
+	default:
+		return &mcp.CallToolResult{IsError: true}, nil, fmt.Errorf("unsupported dnszoneclasses action: %s", in.Action)
+	}
+}
+
 // APIs tool: list/get CRDs under the project control-plane.
 // - {"action":"list","project":"proj"}
 // - {"action":"get","project":"proj","name":"domains"}
@@ -632,7 +804,7 @@ func toolAPIs(ctx context.Context, _ *mcp.CallToolRequest, in APIInfoInput) (*mc
 
 // NewMCPServer constructs the MCP server with all registered tools.
 func NewMCPServer() *mcp.Server {
-	s := mcp.NewServer(&mcp.Implementation{Name: "datum-mcp", Version: "0.1.0"}, nil)
+	s := mcp.NewServer(&mcp.Implementation{Name: "datum-mcp", Version: "0.1.4"}, nil)
 	mcp.AddTool(s, &mcp.Tool{Name: "organizations", Description: "Manage organization context. Actions: list|get|set (name)."}, toolOrganizationMemberships)
 	mcp.AddTool(s, &mcp.Tool{Name: "projects", Description: "Manage projects. Actions: list|get|create|set. list/create require active org or 'org'; set uses body.name."}, toolProjects)
 	mcp.AddTool(s, &mcp.Tool{Name: "users", Description: "List users under the active org or 'org'. Actions: list."}, toolUsers)
@@ -641,6 +813,9 @@ func NewMCPServer() *mcp.Server {
 	mcp.AddTool(s, &mcp.Tool{Name: "httproutes", Description: "CRUD for HTTP routes. Actions: list|get|create|update|delete. Fields: project (optional), id (for get/update/delete), body (for create/update)."}, toolHTTPRoutes)
 	mcp.AddTool(s, &mcp.Tool{Name: "gateways", Description: "CRUD for Gateways. Actions: list|get|create|update|delete. Fields: project (optional), id (for get/update/delete), body (for create/update)."}, toolGateways)
 	mcp.AddTool(s, &mcp.Tool{Name: "trafficprotectionpolicies", Description: "CRUD for TrafficProtectionPolicies. Actions: list|get|create|update|delete. Fields: project (optional), id (for get/update/delete), body (for create/update). Policies apply to Gateways or HTTPRoutes."}, toolTrafficProtectionPolicies)
+	mcp.AddTool(s, &mcp.Tool{Name: "dnszones", Description: "CRUD for DNSZones. Actions: list|get|create|update|delete. Fields: project (optional), id (for get/update/delete), body (for create/update)."}, toolDNSZones)
+	mcp.AddTool(s, &mcp.Tool{Name: "dnsrecordsets", Description: "CRUD for DNSRecordSets. Actions: list|get|create|update|delete. Fields: project (optional), id (for get/update/delete), body (for create/update)."}, toolDNSRecordSets)
+	mcp.AddTool(s, &mcp.Tool{Name: "dnszoneclasses", Description: "List/get DNSZoneClasses (cluster-scoped). Actions: list|get. Fields: project (optional), id (for get)."}, toolDNSZoneClasses)
 	mcp.AddTool(s, &mcp.Tool{Name: "apis", Description: "List/get CRDs under the current project. Actions: list|get. Fields: project (optional), name (for get)."}, toolAPIs)
 	return s
 }


### PR DESCRIPTION
This pull request adds DNS management capabilities to the MCP server, enabling CRUD operations for DNS zones and record sets, as well as listing DNS zone classes. It introduces three new tools (`dnszones`, `dnsrecordsets`, and `dnszoneclasses`) and registers them with the server. Additionally, the MCP server version is updated.

DNS management features:

* Added `toolDNSZones`, `toolDNSRecordSets`, and `toolDNSZoneClasses` functions to `internal/server/server.go`, supporting CRUD operations for DNS zones and record sets, and listing/getting DNS zone classes.

Tool registration and versioning:

* Registered the new DNS tools (`dnszones`, `dnsrecordsets`, `dnszoneclasses`) with the MCP server in `NewMCPServer`, including descriptions of their supported actions and fields.
* Updated the MCP server implementation version from `0.1.0` to `0.1.4` in `NewMCPServer`.